### PR TITLE
nongnu: Add heroic.

### DIFF
--- a/nonguix/multiarch-container.scm
+++ b/nonguix/multiarch-container.scm
@@ -271,6 +271,7 @@ in a sandboxed FHS environment."
                                "^QT_X11_NO_MITSHM$"
                                "^SDL_"
                                "^STEAM_"
+                               "^SSL_" ; SSL certificate environment, needed by curl for Heroic.
                                "^VDPAU_DRIVER_PATH$" ; For VDPAU drivers.
                                "^XAUTHORITY$"
                                ;; Matching all ^XDG_ vars causes issues
@@ -480,6 +481,7 @@ application."
                 ((,union64 "lib/locale") . "/run/current-system/locale")
                 ((,union64 "sbin/ldconfig") . "/sbin/ldconfig")
                 ((,union64 "share/mime") . "/usr/share/mime") ; Steam tray icon.
+                ((,union64 "share/glib-2.0") . "/usr/share/glib-2.0") ; Heroic interface.
                 ((,union64 "share/drirc.d") . "/usr/share/drirc.d")
                 ((,union64 "share/fonts") . "/run/current-system/profile/share/fonts")
                 ((,union64 "etc/fonts") . "/etc/fonts")


### PR DESCRIPTION
* nongnu/packages/steam-client.scm: Rename to ...
* nongnu/packages/game-client.scm: ... this. (heroic-client, heroic-extra-client-libs, heroic-container, heroic-nvidia-container, heroic, heroic-nvidia): New variables.
* nonguix/multi-arch-container.scm (make-container-wrapper): Preserve "^SSL_" for heroic to use curl.
(make-internal-script): Add symlink for "/usrshare/glib-2.0".